### PR TITLE
Use case where it needs to be shown only month and year in the picker

### DIFF
--- a/src/ngx-moderndatepicker/component/ngx-moderndatepicker.component.html
+++ b/src/ngx-moderndatepicker/component/ngx-moderndatepicker.component.html
@@ -2,51 +2,53 @@
   <input type="text" *ngIf="!headless" class="ngx-moderndatepicker-input" [(ngModel)]="displayValue" readonly [placeholder]="placeholder"
     [ngClass]="addClass" [ngStyle]="addStyle" [id]="fieldId" [disabled]="disabled" (click)="toggle()" />
   <ng-content></ng-content>
-  <div class="ngx-moderndatepicker-calendar-container ngx-moderndatepicker-position-{{position}}" [ngClass]="{ 'select-only-month-and-year': selectOnlyMonthAndYear }" *ngIf="isOpened">
+  <div class="ngx-moderndatepicker-calendar-container ngx-moderndatepicker-position-{{position}}" [ngClass]="{ 'no-date': !selectablesFromPicker.date }" *ngIf="isOpened">
     <div class="topbar-container">
-      <div class="main-calendar-selection-year">
-        <svg width="15px" height="15px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-  	       viewBox="0 0 489.6 489.6" style="enable-background:new 0 0 489.6 489.6;" xml:space="preserve"
-          (click)="view === 'year' && prevYear()">
-          <g>
-          	<g>
-          		<path style="fill:#2C2F33;" d="M244.8,489.6c135,0,244.8-109.8,244.8-244.8S379.8,0,244.8,0S0,109.8,0,244.8
-          			S109.8,489.6,244.8,489.6z M244.8,19.8c124.1,0,225,100.9,225,225s-100.9,225-225,225s-225-100.9-225-225S120.7,19.8,244.8,19.8z"
-          			/>
-          		<path style="fill:#3C92CA;" d="M265.5,326.1c1.9,1.9,4.5,2.9,7,2.9s5.1-1,7-2.9c3.9-3.9,3.9-10.1,0-14l-67.3-67.3l67.3-67.3
-          			c3.9-3.9,3.9-10.1,0-14s-10.1-3.9-14,0l-74.3,74.3c-3.9,3.9-3.9,10.1,0,14L265.5,326.1z"/>
-          	</g>
-          </g>
-        </svg>
-        <span class="topbar-title" (click)="toggleView(); initYears();">{{ barTitle }}</span>
-        <svg width="15px" height="15px" viewBox="0 0 6 10" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-  	       viewBox="0 0 489.6 489.6" style="enable-background:new 0 0 489.6 489.6;" xml:space="preserve"
-          (click)="view === 'year' && nextYear()">
-          <g>
-          	<g>
-          		<path style="fill:#2C2F33;" d="M244.8,489.6c135,0,244.8-109.8,244.8-244.8S379.8,0,244.8,0S0,109.8,0,244.8
-          			S109.8,489.6,244.8,489.6z M244.8,19.8c124.1,0,225,100.9,225,225s-100.9,225-225,225s-225-100.9-225-225S120.7,19.8,244.8,19.8z"
-          			/>
-          		<path style="fill:#3C92CA;" d="M210,326.1c1.9,1.9,4.5,2.9,7,2.9s5.1-1,7-2.9l74.3-74.3c1.9-1.9,2.9-4.4,2.9-7s-1-5.1-2.9-7
-          			L224,163.5c-3.9-3.9-10.1-3.9-14,0s-3.9,10.1,0,14l67.3,67.3L210,312.1C206.2,316,206.2,322.3,210,326.1z"/>
-          	</g>
-          </g>
-        </svg>
+      <div class="main-calendar-selection-year"  *ngIf="selectablesFromPicker.year" >
+          <svg width="15px" height="15px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+             viewBox="0 0 489.6 489.6" style="enable-background:new 0 0 489.6 489.6;" xml:space="preserve"
+            (click)="view === 'year' && prevYear()">
+            <g>
+              <g>
+                <path style="fill:#2C2F33;" d="M244.8,489.6c135,0,244.8-109.8,244.8-244.8S379.8,0,244.8,0S0,109.8,0,244.8
+                  S109.8,489.6,244.8,489.6z M244.8,19.8c124.1,0,225,100.9,225,225s-100.9,225-225,225s-225-100.9-225-225S120.7,19.8,244.8,19.8z"
+                  />
+                <path style="fill:#3C92CA;" d="M265.5,326.1c1.9,1.9,4.5,2.9,7,2.9s5.1-1,7-2.9c3.9-3.9,3.9-10.1,0-14l-67.3-67.3l67.3-67.3
+                  c3.9-3.9,3.9-10.1,0-14s-10.1-3.9-14,0l-74.3,74.3c-3.9,3.9-3.9,10.1,0,14L265.5,326.1z"/>
+              </g>
+            </g>
+          </svg>
+          <span class="topbar-title" (click)="toggleView(); initYears();">{{ barTitle }}</span>
+          <svg width="15px" height="15px" viewBox="0 0 6 10" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+             viewBox="0 0 489.6 489.6" style="enable-background:new 0 0 489.6 489.6;" xml:space="preserve"
+            (click)="view === 'year' && nextYear()">
+            <g>
+              <g>
+                <path style="fill:#2C2F33;" d="M244.8,489.6c135,0,244.8-109.8,244.8-244.8S379.8,0,244.8,0S0,109.8,0,244.8
+                  S109.8,489.6,244.8,489.6z M244.8,19.8c124.1,0,225,100.9,225,225s-100.9,225-225,225s-225-100.9-225-225S120.7,19.8,244.8,19.8z"
+                  />
+                <path style="fill:#3C92CA;" d="M210,326.1c1.9,1.9,4.5,2.9,7,2.9s5.1-1,7-2.9l74.3-74.3c1.9-1.9,2.9-4.4,2.9-7s-1-5.1-2.9-7
+                  L224,163.5c-3.9-3.9-10.1-3.9-14,0s-3.9,10.1,0,14l67.3,67.3L210,312.1C206.2,316,206.2,322.3,210,326.1z"/>
+              </g>
+            </g>
+          </svg>
       </div>
-      <div class="main-calendar-day-names" *ngIf="view === 'year' && !selectOnlyMonthAndYear">
+      <div class="main-calendar-day-names" [ngClass]="{ 'no-year': selectablesFromPicker.date && selectablesFromPicker.month && !selectablesFromPicker.year,  'no-month-no-year': !selectablesFromPicker.year && !selectablesFromPicker.month}" *ngIf="view === 'year' && selectablesFromPicker.date">
         <span class="day-name-unit" *ngFor="let name of dayNames">{{ name }}</span>
       </div>
     </div>
-    <div class="main-calendar-container" *ngIf="view === 'year'">
-      <div class="main-calendar-month-names" [ngClass]="{ 'select-only-month-and-year': selectOnlyMonthAndYear}">
-        <div class="month-name-unit" *ngFor="let month of monthNames; let index = index" (click)="month.isSelectable && selectMonth(index)">
-          <span class="month-unit"
-            [ngClass]="{ 'is-this-month': month.isThisMonth,  'is-disabled': !month.isSelectable ,'is-selected': month.isSelected}">
-            {{ month.name }}
-          </span>
+    <div class="main-calendar-container" *ngIf="view === 'year' && (selectablesFromPicker.month || selectablesFromPicker.date )" >
+      <ng-container *ngIf="selectablesFromPicker.month">
+        <div class="main-calendar-month-names" [ngClass]="{ 'no-date': !selectablesFromPicker.date}">
+          <div class="month-name-unit" *ngFor="let month of monthNames; let index = index" (click)="month.isSelectable && selectMonth(index)">
+            <span class="month-unit"
+              [ngClass]="{ 'is-this-month': month.isThisMonth,  'is-disabled': !month.isSelectable ,'is-selected': month.isSelected}">
+              {{ month.name }}
+            </span>
+          </div>
         </div>
-      </div>
-      <div class="main-calender-days-container" *ngIf="!selectOnlyMonthAndYear">
+      </ng-container>
+      <div class="main-calender-days-container"  [ngClass]="{ 'no-month':!selectablesFromPicker.month,  'no-month-no-year':!selectablesFromPicker.year && !selectablesFromPicker.month  }" *ngIf="selectablesFromPicker.date" >
         <div class="main-calendar-days">
           <div class="day-unit" *ngFor="let day of days; let i = index;" >
             <span [ngClass]="{ 'is-prev-month': !day.inThisMonth, 'is-today': day.isToday,  'is-disabled': !day.isSelectable, 'is-weekend': day.isWeekend , 'is-holiday' : day.isHoliday, 'is-selected': day.isSelected}"
@@ -57,7 +59,7 @@
         </div>
        </div>
       </div>
-    <div class="main-calendar-container" *ngIf="view === 'years'">
+    <div class="main-calendar-container" *ngIf="view === 'years' || (!selectablesFromPicker.date && !selectablesFromPicker.month)">
       <div class="main-calendar-years">
         <span class="year-unit" *ngFor="let year of years; let i = index;" [ngClass]="{ 'is-selected': year.isThisYear , 'is-today': year.isToday , 'is-disabled' : !year.isSelectable}" (click)="year.isSelectable && setYear(i)">{{ year.year }}</span>
       </div>

--- a/src/ngx-moderndatepicker/component/ngx-moderndatepicker.component.html
+++ b/src/ngx-moderndatepicker/component/ngx-moderndatepicker.component.html
@@ -2,7 +2,7 @@
   <input type="text" *ngIf="!headless" class="ngx-moderndatepicker-input" [(ngModel)]="displayValue" readonly [placeholder]="placeholder"
     [ngClass]="addClass" [ngStyle]="addStyle" [id]="fieldId" [disabled]="disabled" (click)="toggle()" />
   <ng-content></ng-content>
-  <div class="ngx-moderndatepicker-calendar-container ngx-moderndatepicker-position-{{position}}" *ngIf="isOpened">
+  <div class="ngx-moderndatepicker-calendar-container ngx-moderndatepicker-position-{{position}}" [ngClass]="{ 'select-only-month-and-year': selectOnlyMonthAndYear }" *ngIf="isOpened">
     <div class="topbar-container">
       <div class="main-calendar-selection-year">
         <svg width="15px" height="15px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
@@ -33,12 +33,12 @@
           </g>
         </svg>
       </div>
-      <div class="main-calendar-day-names" *ngIf="view === 'year'">
+      <div class="main-calendar-day-names" *ngIf="view === 'year' && !selectOnlyMonthAndYear">
         <span class="day-name-unit" *ngFor="let name of dayNames">{{ name }}</span>
       </div>
     </div>
     <div class="main-calendar-container" *ngIf="view === 'year'">
-      <div class="main-calendar-month-names">
+      <div class="main-calendar-month-names" [ngClass]="{ 'select-only-month-and-year': selectOnlyMonthAndYear}">
         <div class="month-name-unit" *ngFor="let month of monthNames; let index = index" (click)="month.isSelectable && selectMonth(index)">
           <span class="month-unit"
             [ngClass]="{ 'is-this-month': month.isThisMonth,  'is-disabled': !month.isSelectable ,'is-selected': month.isSelected}">
@@ -46,7 +46,7 @@
           </span>
         </div>
       </div>
-      <div class="main-calender-days-container">
+      <div class="main-calender-days-container" *ngIf="!selectOnlyMonthAndYear">
         <div class="main-calendar-days">
           <div class="day-unit" *ngFor="let day of days; let i = index;" >
             <span [ngClass]="{ 'is-prev-month': !day.inThisMonth, 'is-today': day.isToday,  'is-disabled': !day.isSelectable, 'is-weekend': day.isWeekend , 'is-holiday' : day.isHoliday, 'is-selected': day.isSelected}"

--- a/src/ngx-moderndatepicker/component/ngx-moderndatepicker.component.scss
+++ b/src/ngx-moderndatepicker/component/ngx-moderndatepicker.component.scss
@@ -147,6 +147,11 @@ $grey-background: #e0e0e0;
             }
           }
       }
+
+      .select-only-month-and-year {
+        width: 184px;
+      }
+
       .main-calendar-days, .main-calendar-years {
         padding: 15px 5px;
         width: 100%;
@@ -229,4 +234,9 @@ $grey-background: #e0e0e0;
        }
     }
   }
+
+  .select-only-month-and-year {
+    width: 184px;
+  }
+ 
 }

--- a/src/ngx-moderndatepicker/component/ngx-moderndatepicker.component.scss
+++ b/src/ngx-moderndatepicker/component/ngx-moderndatepicker.component.scss
@@ -148,7 +148,7 @@ $grey-background: #e0e0e0;
           }
       }
 
-      .select-only-month-and-year {
+      .no-date {
         width: 184px;
       }
 
@@ -235,8 +235,20 @@ $grey-background: #e0e0e0;
     }
   }
 
-  .select-only-month-and-year {
+  .no-date {
     width: 184px;
   }
- 
+
+ .no-year, .no-month {
+    margin-left: 109px;
+  }
+
+  .no-month-no-year {
+    margin-left: 0px;
+  }
+
+  .no-date-no-month {
+    margin-left: 0px;
+  }
 }
+

--- a/src/ngx-moderndatepicker/component/ngx-moderndatepicker.component.ts
+++ b/src/ngx-moderndatepicker/component/ngx-moderndatepicker.component.ts
@@ -47,8 +47,8 @@ export interface ModernDatePickerOptions {
    /** Sunday is 0 , Highlights the weekends with gray background**/
   holidayList?: Array<Date>;
   /** List of Holidays **/
-  selectOnlyMonthAndYear?: boolean;
-  //If true, the picker will show only Month and year, one such use case when selecting expiry date where it needs to show only month and year
+  views?: Array<'month' | 'date' | 'year'>;
+   //its an array of strings which can contain either of the items 'month', 'date' , 'year'
 }
 
 // Counter for calculating the auto-incrementing field ID
@@ -126,7 +126,8 @@ export class NgxModerndatepickerComponent implements OnInit, OnChanges, ControlV
   fieldId: string;
   disabled: boolean;
   useEmptyBarTitle: boolean;
-  selectOnlyMonthAndYear: boolean;
+  views: Array<'date' | 'month' | 'year'>;
+  selectablesFromPicker: object = {};
   private onTouchedCallback: () => void = () => { };
   private onChangeCallback: (_: any) => void = () => { };
 
@@ -156,6 +157,9 @@ export class NgxModerndatepickerComponent implements OnInit, OnChanges, ControlV
     this.initYears();
     this.initMonthName();
     this.init();
+    for(let i in this.views) {
+        this.selectablesFromPicker[this.views[i]] = true;
+    }
     // Check if 'position' property is correct
     if (this.positions.indexOf(this.position) === -1) {
       throw new TypeError(`ng-moderndatepicker: invalid position property value '${this.position}' (expected: ${this.positions.join(', ')})`);
@@ -193,7 +197,7 @@ export class NgxModerndatepickerComponent implements OnInit, OnChanges, ControlV
     this.addClass = this.options && this.options.addClass || {};
     this.addStyle = this.options && this.options.addStyle || {};
     this.fieldId = this.options && this.options.fieldId || this.defaultFieldId;
-    this.selectOnlyMonthAndYear = this.options && this.options.selectOnlyMonthAndYear || false;
+    this.views = this.options && this.options && this.options.views && this.options.views.length && this.options.views || ['month', 'date', 'year']; 
   }
 
   nextYear(): void {
@@ -218,15 +222,24 @@ export class NgxModerndatepickerComponent implements OnInit, OnChanges, ControlV
   }
 
   setYear(i: number): void {
-    this.date = setYear(this.date, this.years[i].year);
-    this.init();
-    this.initMonthName();
-    this.view = 'year';
+    this.date = setYear(this.date, this.years[i].year); // getting the last of the selected month of the given year
+    if(!this.selectablesFromPicker['date'] && !this.selectablesFromPicker['month']) {
+      this.initMonthName();
+      this.view = 'year';
+      this.value = this.date;
+      this.init();
+      this.close()
+    } else {
+      this.init();
+      this.initMonthName();
+      this.view = 'year';
+    }
+   
   }
 
   selectMonth(i: number): void {
     this.date = setMonth(this.date,i);
-    if(this.selectOnlyMonthAndYear) {
+    if(!this.selectablesFromPicker['date']) {
       this.date = new Date(this.date.getFullYear(), this.date.getMonth() + 1, 0); // getting the last of the selected month of the given year
       this.initMonthName();
       this.view = 'year';

--- a/src/ngx-moderndatepicker/component/ngx-moderndatepicker.component.ts
+++ b/src/ngx-moderndatepicker/component/ngx-moderndatepicker.component.ts
@@ -47,6 +47,8 @@ export interface ModernDatePickerOptions {
    /** Sunday is 0 , Highlights the weekends with gray background**/
   holidayList?: Array<Date>;
   /** List of Holidays **/
+  selectOnlyMonthAndYear?: boolean;
+  //If true, the picker will show only Month and year, one such use case when selecting expiry date where it needs to show only month and year
 }
 
 // Counter for calculating the auto-incrementing field ID
@@ -124,6 +126,7 @@ export class NgxModerndatepickerComponent implements OnInit, OnChanges, ControlV
   fieldId: string;
   disabled: boolean;
   useEmptyBarTitle: boolean;
+  selectOnlyMonthAndYear: boolean;
   private onTouchedCallback: () => void = () => { };
   private onChangeCallback: (_: any) => void = () => { };
 
@@ -190,6 +193,7 @@ export class NgxModerndatepickerComponent implements OnInit, OnChanges, ControlV
     this.addClass = this.options && this.options.addClass || {};
     this.addStyle = this.options && this.options.addStyle || {};
     this.fieldId = this.options && this.options.fieldId || this.defaultFieldId;
+    this.selectOnlyMonthAndYear = this.options && this.options.selectOnlyMonthAndYear || false;
   }
 
   nextYear(): void {
@@ -222,9 +226,18 @@ export class NgxModerndatepickerComponent implements OnInit, OnChanges, ControlV
 
   selectMonth(i: number): void {
     this.date = setMonth(this.date,i);
-    this.init();
-    this.initMonthName();
-    this.view = 'year';
+    if(this.selectOnlyMonthAndYear) {
+      this.date = new Date(this.date.getFullYear(), this.date.getMonth() + 1, 0); // getting the last of the selected month of the given year
+      this.initMonthName();
+      this.view = 'year';
+      this.value = this.date;
+      this.init();
+      this.close()
+    } else {
+      this.init();
+      this.initMonthName();
+      this.view = 'year';
+    }
   }
   /**
    * Checks if specified date is in range of min and max dates


### PR DESCRIPTION
In the current ngx-moderndatepicker there is no provision to select month and year from the picker. One such use case is needed in expiry date (where we just need to show the MM/YYYY)

a new property called 'selectOnlyMonthAndYear' which is a boolean type has been added in the options, So if this property is set to true then user will see the Month and year in the picker, so on a given year if any of the month is selected , by default the last day of the month of the given year will be set as a value.

